### PR TITLE
Fix deployed Swagger documentation

### DIFF
--- a/packages/api/docs/swagger.js
+++ b/packages/api/docs/swagger.js
@@ -33,7 +33,7 @@ const swaggerJSDocOptions = {
       },
     ],
   },
-  apis: ['./routes/*.js', './models/*.js'],
+  apis: ['**/routes/*.js', '**/models/*.js'],
 };
 
 const swaggerSpec = swaggerJSDoc(swaggerJSDocOptions);

--- a/packages/api/docs/swagger.js
+++ b/packages/api/docs/swagger.js
@@ -2,6 +2,21 @@ require('dotenv').config();
 
 const swaggerUI = require('swagger-ui-express');
 const swaggerJSDoc = require('swagger-jsdoc');
+const { APP_URL, NODE_ENV, PORT } = process.env;
+
+const servers = [
+  {
+    url: APP_URL,
+    description: 'Production server',
+  },
+];
+
+if (NODE_ENV === 'development') {
+  servers.unshift({
+    url: `http://localhost:${PORT}`,
+    description: 'Development server',
+  });
+}
 
 const swaggerJSDocOptions = {
   definition: {
@@ -10,17 +25,12 @@ const swaggerJSDocOptions = {
       title: 'LYFE REST API',
       version: '1.0.0',
     },
-    servers: [
-      {
-        url: `http://localhost:${process.env.PORT}`,
-        description: 'Development server',
-      },
-    ],
+    servers: servers,
     tags: [
       {
         name: 'users',
         description: 'Create and manage users and user sessions.',
-      }
+      },
     ],
   },
   apis: ['./routes/*.js', './models/*.js'],


### PR DESCRIPTION
The API documentation appeared locally but did not build during deployment. Fixed glob pattern in Swagger configuration to match file paths in local environment and remote environment.