### PR TITLE
Add routes for users, reminders and health

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node ./packages/api/server.js
+web: npm start

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "client": "cd ./packages/client && npm start",
     "client-build": "cd ./packages/client && npm install && npm run build",
     "client-install": "cd ./packages/client && npm install",
-    "heroku-postbuild": "npm run api-install && npm run client-build",
-    "install": "npm run api-install && npm run client-install"
+    "heroku-postbuild": "npm run client-build",
+    "install": "npm run api-install && npm run client-install",
+    "start": "cd ./packages/api && npm start"
   },
   "license": "ISC",
   "dependencies": {

--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -1,4 +1,10 @@
-JWT_SECRET="jsonwebtoken secret"
-MONGODB_URI='mongodb://localhost/lyfe'
+APP_URL=https://lyfe.studio
 NODE_ENV=development
+
+MONGODB_URI=mongodb://localhost/lyfe
 PORT=3001
+
+JWT_SECRET="jsonwebtoken secret"
+
+SENDGRID_API_KEY="sendgrid api key"
+FROM_EMAIL="fromemail@example.com"

--- a/packages/api/docs/securityScheme.js
+++ b/packages/api/docs/securityScheme.js
@@ -1,0 +1,10 @@
+/**
+ * @openapi
+ * 
+ * components:
+ *  securitySchemes:
+ *    BearerAuth:
+ *      type: http
+ *      scheme: bearer
+ *      bearerFormat: JWT 
+ */

--- a/packages/api/docs/swagger.js
+++ b/packages/api/docs/swagger.js
@@ -33,7 +33,7 @@ const swaggerJSDocOptions = {
       },
     ],
   },
-  apis: ['**/routes/*.js', '**/models/*.js'],
+  apis: ['**/docs/*.js', '**/models/*.js', '**/routes/*.js', '**/util/*.js'],
 };
 
 const swaggerSpec = swaggerJSDoc(swaggerJSDocOptions);

--- a/packages/api/docs/swagger.js
+++ b/packages/api/docs/swagger.js
@@ -31,6 +31,14 @@ const swaggerJSDocOptions = {
         name: 'users',
         description: 'Create and manage users and user sessions.',
       },
+      {
+        name: 'reminders',
+        description: 'Create and manage reminders and reminder types.'
+      },
+      {
+        name: 'health',
+        description: 'Manage health profile.'
+      },
     ],
   },
   apis: ['**/docs/*.js', '**/models/*.js', '**/routes/*.js', '**/util/*.js'],

--- a/packages/api/middleware/routerMiddleware.js
+++ b/packages/api/middleware/routerMiddleware.js
@@ -5,16 +5,6 @@ const { sendError } = require('../util/responses');
 const { JWT_SECRET } = process.env;
 
 /**
- * Generate a new JWT.
- * 
- * @param {Object} payload JSON object to be embedded in JWT
- * @returns {String} The JWT.
- */
-const generateJWT = (payload) => {
-  return jwt.sign(payload, JWT_SECRET, { expiresIn: '1h' });
-};
-
-/**
  *  Authenticate the JWT; Verify that it is valid.
  * 
  * @param {Object} req Express request object.
@@ -41,6 +31,5 @@ const authenticateJWT = (req, res, next) => {
 };
 
 module.exports = {
-  generateJWT: generateJWT,
-  authenticateJWT: authenticateJWT,
+  authenticateJWT,
 }

--- a/packages/api/middleware/routerMiddleware.js
+++ b/packages/api/middleware/routerMiddleware.js
@@ -28,7 +28,11 @@ const authenticateJWT = (req, res, next) => {
 
   jwt.verify(token, JWT_SECRET, (err, decoded) => {
     if (err) {
-      sendError(res, '401', 'Access denied. Invalid token.');
+      sendError(
+        res,
+        '401',
+        'Access denied. This request requires user authentication.'
+      );
     } else {
       req.tokenPayload = decoded;
       next();

--- a/packages/api/middleware/serverMiddleware.js
+++ b/packages/api/middleware/serverMiddleware.js
@@ -10,8 +10,8 @@ module.exports = {
     server.use(express.json());
     
     // In production serve client build as static files.
-    if (NODE_ENV === 'production') {
-      server.use(express.static(path.resolve(__dirname, '../../client/build')));
-    }
+    // if (NODE_ENV === 'production') {
+    //   server.use(express.static(path.resolve(__dirname, '../../client/build')));
+    // }
   },
 };

--- a/packages/api/middleware/serverMiddleware.js
+++ b/packages/api/middleware/serverMiddleware.js
@@ -2,10 +2,12 @@ require('dotenv').config();
 
 const path = require('path');
 const express = require('express');
+const cors = require('cors');
 const { NODE_ENV } = process.env;
 
 module.exports = {
   serverMiddleware: (server) => {
+    server.use(cors());
     server.use(express.urlencoded({ extended: true }));
     server.use(express.json());
     

--- a/packages/api/middleware/serverMiddleware.js
+++ b/packages/api/middleware/serverMiddleware.js
@@ -10,8 +10,8 @@ module.exports = {
     server.use(express.json());
     
     // In production serve client build as static files.
-    // if (NODE_ENV === 'production') {
-    //   server.use(express.static(path.resolve(__dirname, '../../client/build')));
-    // }
+    if (NODE_ENV === 'production') {
+      server.use(express.static(path.resolve(__dirname, '../../client/build')));
+    }
   },
 };

--- a/packages/api/models/Health.embeddedModel.js
+++ b/packages/api/models/Health.embeddedModel.js
@@ -1,0 +1,79 @@
+const mongoose = require('mongoose');
+const emergencyContactSchema = require('./EmergencyContact.embeddedModel');
+const medicationSchema = require('./Medication.embeddedModel');
+
+/**
+ * @openapi
+ *
+ * components:
+ *  schemas:
+ *    Health:
+ *      title: Health
+ *      type: object
+ *      properties:
+ *        dateOfBirth:
+ *          type: string
+ *          format: date
+ *        height:
+ *          type: integer
+ *          example: 70
+ *          summary: The height in inches.
+ *        weight:
+ *          type: integer
+ *          example: 200
+ *          summary: The weight in lbs.
+ *        gender:
+ *          type: string,
+ *          enum: [Male, Female, Prefer not to say]
+ *          example: Male
+ *        bloodType:
+ *          type:  string,
+ *          enum: [A+, A-, AB+, AB-, B+, B-, O+, O-, Unknown]
+ *          example: B+
+ *        allergies:
+ *          type: array
+ *          items:
+ *            type: string
+ *          example: ['Peanuts']
+ *        healthConditions:
+ *          type: array
+ *          items:
+ *            type: string
+ *          example: ['Asthma', 'High Blood Pressure']
+ *        medications:
+ *          type: array
+ *          items:
+ *            $ref: '#/components/schemas/Medication'
+ *        emergencyContacts:
+ *          type: array
+ *          items:
+ *            $ref: '#/components/schemas/EmergencyContact'
+ *        additionalInformation:
+ *          type: string
+ */
+const healthSchema = new mongoose.Schema({
+  dateOfBirth: Date,
+  height: {
+    type: Number,
+  },
+  weight: {
+    type: Number,
+  },
+  gender: {
+    type: String,
+    enum: ['Male', 'Female', 'Prefer not to say'],
+  },
+  bloodType: {
+    type: String,
+    enum: ['A+', 'A-', 'AB+', 'AB-', 'B+', 'B-', 'O+', 'O-', 'Unknown'],
+  },
+  allergies: [String],
+  healthConditions: [String],
+  medications: [medicationSchema],
+  emergencyContacts: [emergencyContactSchema],
+  additionalInformation: {
+    type: String,
+  },
+});
+
+module.exports = healthSchema;

--- a/packages/api/models/Medication.embeddedModel.js
+++ b/packages/api/models/Medication.embeddedModel.js
@@ -1,0 +1,41 @@
+const mongoose = require('mongoose');
+const reminderSchema = require('./Reminder.embeddedModel');
+
+/**
+ * @openapi
+ * 
+ * components:
+ *  schemas:
+ *    Medication:
+ *      title: Medication
+ *      type: object
+ *      required:
+ *        - name
+ *      properties:
+ *        name:
+ *          type: string
+ *          example: Naproxen
+ *        dosage:
+ *          type: string
+ *          example: 1 tablet (500mg)
+ *        frequency:
+ *          type: string
+ *          example: Twice a day
+ *        reminder: 
+ *          $ref: '#/components/schemas/Reminder'     
+ */
+const medicationSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: [true, 'Name is required for Medication.'],
+  },
+  dosage: {
+    type: String,
+  },
+  frequency: {
+    type: String,
+  },
+  reminder: reminderSchema,
+});
+
+module.exports = medicationSchema;

--- a/packages/api/models/Reminder.embeddedModel.js
+++ b/packages/api/models/Reminder.embeddedModel.js
@@ -11,10 +11,11 @@ const locationSchema = require('./Location.embeddedModel');
  *      type: object
  *      required:
  *        - name
+ *        - startDate
  *      properties:
  *        name:
  *          type: string
- *          example: Doctor's Appointment
+ *          example: COP4331
  *        description:
  *          type: string
  *        type:
@@ -23,28 +24,69 @@ const locationSchema = require('./Location.embeddedModel');
  *          example: 5b1ed13e8cea93c6ba72b1da
  *        location:
  *          $ref: '#/components/schemas/Location'
- *        datetime:
+ *        startDate:
+ *          type: string
+ *          format: date-time
+ *        endDate:
+ *          type: string
+ *          format: date-time
+ *        repeat:
+ *          type: boolean
+ *        dailyPattern:
  *          type: array
  *          items:
  *            type: string
- *            format: date
- *        repeat:
- *          type: boolean
+ *            enum: [Sun, Mon, Tues, Wed, Thur, Fri, Sat]
+ *            example: [Mon, Wed]
+ *          summary: The days of the week that this reminder should repeat. Ex. [Mon, Wed, Fri]
+ *        weeklyPattern:
+ *          type: integer
+ *          example: 1
+ *          summary: The number of weeks that this reminder should repeat. Ex. Repeats every 2 weeks
+ *          
  */
 const reminderSchema = new mongoose.Schema({
   name: {
     type: String,
     required: [true, 'Name is required for Reminder.'],
   },
-  description: String,
+  description: {
+    type: String,
+  },
   type: {
-    type: mongoose.Schema.Types.ObjectId, 
-    ref: 'ReminderType' 
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'ReminderType',
   },
   location: locationSchema,
-  // How to model? Can either be a single date like March 15, 2021 or days of the week like MWF
-  datetime: [Date],
+  startDate: {
+    type: Date,
+    required: [true, 'Start date is required for Reminder.'],
+  },
+  endDate: {
+    type: Date,
+  },
   repeat: Boolean,
+  dailyPattern: {
+    type: [String],
+    enum: ['Sun', 'Mon', 'Tues', 'Wed', 'Thur', 'Fri', 'Sat'],
+    default: undefined,
+    required: [
+      function () {
+        return this.repeat;
+      },
+      'Daily pattern is required when Reminder repeats.',
+    ],
+  },
+  weeklyPattern: {
+    type: Number,
+    min: [1, 'Weekly pattern for Reminder must be greater than 0.'],
+    required: [
+      function () {
+        return this.repeat;
+      },
+      'Weekly pattern is required when Reminder repeats.',
+    ],
+  },
 });
 
 module.exports = reminderSchema;

--- a/packages/api/models/ReminderType.js
+++ b/packages/api/models/ReminderType.js
@@ -1,11 +1,39 @@
 const mongoose = require('mongoose');
 
+/**
+ * @openapi
+ * 
+ * components:
+ *  schemas:
+ *    ReminderType:
+ *      title: ReminderType
+ *      type: object
+ *      required:
+ *        - type
+ *        - user
+ *      properties:
+ *        type:
+ *          type: string
+ *          example: Class
+ *        color:
+ *          type: string
+ *          example: '#001C5C'
+ *        user:
+ *          type: string
+ *          format: objectId
+ *          example: 5b1ed13e8cea93c6ba72b1da
+ */
 const reminderTypeSchema = new mongoose.Schema({
   type: {
     type: String,
     required: [true, 'Type is required for Reminder Type.'],
   },
   color: String,
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+    required: [true, 'User Id is required for Reminder Type.'],
+  },
 });
 
 module.exports = mongoose.model('ReminderType', reminderTypeSchema);

--- a/packages/api/models/User.js
+++ b/packages/api/models/User.js
@@ -4,7 +4,7 @@ const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 const mongoose = require('mongoose');
 const randomBytes = require('randombytes');
-const emergencyContactSchema = require('./EmergencyContact.embeddedModel');
+const healthSchema = require('./Health.embeddedModel');
 const reminderSchema = require('./Reminder.embeddedModel');
 const saltRounds = 12;
 const { JWT_SECRET } = process.env;
@@ -48,18 +48,6 @@ const { JWT_SECRET } = process.env;
  *        verificationToken:
  *          type: string
  *          example: cb68ea67877553f1047c9a87c1f3e98e884f2ef36850bdcf800b728c3a55be83
- *        dateOfBirth:
- *          type: string
- *          format: date
- *        allergies:
- *          type: array
- *          items:
- *            type: string
- *          example: ['Peanuts']
- *        emergencyContact:
- *          type: array
- *          items:
- *            $ref: '#/components/schemas/EmergencyContact'
  *        reminders:
  *          type: array
  *          items:
@@ -69,6 +57,8 @@ const { JWT_SECRET } = process.env;
  *          items:
  *            type: objectId
  *          example: ['5b1ed13e8cea93c6ba72b1da', '5b1ed13e8cea93c6ba72b1db']
+ *        health:
+ *          $ref: '#/components/schemas/Ice' 
  */
 const userSchema = new mongoose.Schema({
   firstName: {
@@ -117,11 +107,9 @@ const userSchema = new mongoose.Schema({
   verificationToken: {
     type: String,
   },
-  dateOfBirth: Date,
-  allergies: [String],
-  emergencyContacts: [emergencyContactSchema],
   reminders: [reminderSchema],
   courses: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Course' }],
+  health: healthSchema,
 });
 
 /**

--- a/packages/api/models/User.js
+++ b/packages/api/models/User.js
@@ -58,7 +58,7 @@ const { JWT_SECRET } = process.env;
  *            type: objectId
  *          example: ['5b1ed13e8cea93c6ba72b1da', '5b1ed13e8cea93c6ba72b1db']
  *        health:
- *          $ref: '#/components/schemas/Ice' 
+ *          $ref: '#/components/schemas/Health' 
  */
 const userSchema = new mongoose.Schema({
   firstName: {

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -8,11 +8,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@sendgrid/mail": "^7.4.2",
         "bcrypt": "^5.0.1",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",
         "jsonwebtoken": "^8.5.1",
         "mongoose": "^5.12.1",
+        "randombytes": "^2.1.0",
         "swagger-jsdoc": "^6.1.0",
         "swagger-ui-express": "^4.1.6"
       },
@@ -109,6 +111,41 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@sendgrid/client": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.4.2.tgz",
+      "integrity": "sha512-bu8lLbRD+OV7YsYNemEy8DRoxs8/8u325EXNlQ3VaqhcpbM0eSvdL5e5Wa7VZpbczcNCJmf/sr/uqFmwcO5S+A==",
+      "dependencies": {
+        "@sendgrid/helpers": "^7.4.2",
+        "axios": "^0.21.1"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >=10.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.4.2.tgz",
+      "integrity": "sha512-b/IyBwT4zrOfXA0ISvWZsnhYz+5uAO20n68J8n/6qe5P1E2p0L7kWNTN5LYu0S7snJPUlbEa6FpfrSKzEcP9JA==",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.4.2.tgz",
+      "integrity": "sha512-hvIOnm8c3zVyDnJcyBuAeujmpKX56N3D/LpiZrFuLHjAz4iEHrmL2sJ3iU9O6hxcb07gd1CES+z9Fg7FBT26uQ==",
+      "dependencies": {
+        "@sendgrid/client": "^7.4.2",
+        "@sendgrid/helpers": "^7.4.2"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >=10.*"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -333,6 +370,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "node_modules/axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dependencies": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
@@ -742,6 +787,14 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/defer-to-connect": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
@@ -967,6 +1020,25 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/forwarded": {
@@ -2132,6 +2204,14 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -2902,6 +2982,32 @@
         }
       }
     },
+    "@sendgrid/client": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.4.2.tgz",
+      "integrity": "sha512-bu8lLbRD+OV7YsYNemEy8DRoxs8/8u325EXNlQ3VaqhcpbM0eSvdL5e5Wa7VZpbczcNCJmf/sr/uqFmwcO5S+A==",
+      "requires": {
+        "@sendgrid/helpers": "^7.4.2",
+        "axios": "^0.21.1"
+      }
+    },
+    "@sendgrid/helpers": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.4.2.tgz",
+      "integrity": "sha512-b/IyBwT4zrOfXA0ISvWZsnhYz+5uAO20n68J8n/6qe5P1E2p0L7kWNTN5LYu0S7snJPUlbEa6FpfrSKzEcP9JA==",
+      "requires": {
+        "deepmerge": "^4.2.2"
+      }
+    },
+    "@sendgrid/mail": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.4.2.tgz",
+      "integrity": "sha512-hvIOnm8c3zVyDnJcyBuAeujmpKX56N3D/LpiZrFuLHjAz4iEHrmL2sJ3iU9O6hxcb07gd1CES+z9Fg7FBT26uQ==",
+      "requires": {
+        "@sendgrid/client": "^7.4.2",
+        "@sendgrid/helpers": "^7.4.2"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -3081,6 +3187,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -3400,6 +3514,11 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
     "defer-to-connect": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
@@ -3577,6 +3696,11 @@
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
       }
+    },
+    "follow-redirects": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -4455,6 +4579,14 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
     },
     "range-parser": {
       "version": "1.2.1",

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@sendgrid/mail": "^7.4.2",
         "bcrypt": "^5.0.1",
+        "cors": "^2.8.5",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",
         "jsonwebtoken": "^8.5.1",
@@ -748,6 +749,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -3484,6 +3497,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "crypto-random-string": {
       "version": "2.0.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@sendgrid/mail": "^7.4.2",
     "bcrypt": "^5.0.1",
+    "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,11 +10,13 @@
   },
   "license": "ISC",
   "dependencies": {
+    "@sendgrid/mail": "^7.4.2",
     "bcrypt": "^5.0.1",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.12.1",
+    "randombytes": "^2.1.0",
     "swagger-jsdoc": "^6.1.0",
     "swagger-ui-express": "^4.1.6"
   },

--- a/packages/api/routes/health.js
+++ b/packages/api/routes/health.js
@@ -1,0 +1,222 @@
+const router = require('express').Router();
+const User = require('../models/User');
+const { sendResponse, sendError } = require('../util/responses');
+const { authenticateJWT } = require('../middleware/routerMiddleware');
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/health:
+ *    get:
+ *      security:
+ *        - BearerAuth: []
+ *      tags: [health]
+ *      summary: Get health profile.
+ *      description:  Get health profile for the user contained in the required JSON Web Token. This 
+ *        action can only be performed by an authenticated user.
+ *      operationId: getHealthProfile
+ *      responses:
+ *        200:
+ *          description: Health profile successfully retrieved.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: array
+ *                items:
+ *                  $ref: '#/components/schemas/Health'
+ *        401:
+ *          $ref: '#/components/responses/401Unauthorized'
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.get('/', authenticateJWT, (req, res) => {
+  const userId = req.tokenPayload.id;
+
+  User.findById(userId, 'health')
+    .then((results) => {
+      sendResponse(res, 200, results.health);
+    })
+    .catch((err) => {
+      sendError(res, err, err.message);
+    });
+});
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/health:
+ *    post:
+ *      security:
+ *        - BearerAuth: []
+ *      tags: [health]
+ *      summary: Create health profile.
+ *      description: Create a health profile for the user contained in the required JSON Web Token. 
+ *        This action can only be performed by an authenticated user.
+ *      operationId: createHealthProfile
+ *      requestBody:
+ *        description: Health Profile
+ *        required: true
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: '#/components/schemas/Health'
+ *      responses:
+ *        201:
+ *          description: New health profile successfully created.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: array
+ *                items:
+ *                  $ref: '#/components/schemas/Health'
+ *        400:
+ *          $ref: '#/components/responses/400BadRequest'
+ *        401:
+ *          $ref: '#/components/responses/401Unauthorized'
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.post('/', authenticateJWT, async (req, res) => {
+  const userId = req.tokenPayload.id;
+  const newHealthProfile = req.body;
+  const user = await User.findById(userId);
+
+  if (user) {
+    user.health = newHealthProfile;
+    user.save()
+      .then(updatedUser => {
+        sendResponse(res, 201, updatedUser.health);
+      })
+      .catch(err => {
+        sendError(res, err, err.message);
+      });
+  } else {
+    sendError(res, 500, 'Server failed to fetch this user.');
+  }
+});
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/health:
+ *    put:
+ *      security:
+ *        - BearerAuth: []
+ *      tags: [health]
+ *      summary: Update health profile.
+ *      description: Update the health profile for the user contained in the required JSON Web Token. 
+ *        This action can only be performed by an authenticated user.
+ *      operationId: updateHealthProfile
+ *      requestBody:
+ *        description: Health Profile
+ *        required: true
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: '#/components/schemas/Health'
+ *      responses:
+ *        200:
+ *          description: Health profile successfully updated.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                $ref: '#/components/schemas/Health'
+ *        400:
+ *          $ref: '#/components/responses/400BadRequest'
+ *        401:
+ *          $ref: '#/components/responses/401Unauthorized'
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.put('/', authenticateJWT, async (req, res) => {
+  const updatedFields = req.body;
+  const userId = req.tokenPayload.id;
+  const user = await User.findById(userId);
+
+  if (user) {
+    const updatedHealth = updateHealthFields(user.health, updatedFields);
+    save(user, res, updatedHealth);
+  } else {
+    sendError(res, 500, 'Server failed to fetch this user.');
+  }
+});
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/health:
+ *    delete:
+ *      security:
+ *        - BearerAuth: []
+ *      tags: [health]
+ *      summary: Delete health profile.
+ *      description: Delete the health profile for the user contained in the required JSON Web Token.
+ *        This action can only be performed by an authenticated user.
+ *      operationId: deleteHealthProfile
+ *      responses:
+ *        204:
+ *          description: Health profile successfully deleted.
+ *        401:
+ *          $ref: '#/components/responses/401Unauthorized'
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.delete('/', authenticateJWT, async (req, res) => {
+  const userId = req.tokenPayload.id;
+  const user = await User.findById(userId);
+
+  if (user) {
+    user.health.remove();
+
+    user.save()
+      .then(() => {
+        sendResponse(res, 204, {});
+      })
+      .catch((err) => {
+        sendError(res, err, err.message);
+      });
+  } else {
+    sendError(res, 500, 'Server failed to fetch this user.');
+  }
+});
+
+/**
+ * Save the document and send an OK response. If the document does not validate, abort and send
+ * error HTTP response.
+ * 
+ * @param {Document} doc Mongoose document.
+ * @param {Object} res Express response object.
+ * @param {Object} respBody Response body for the OK HTTP response.
+ */
+const save = (doc, res, respBody) => {
+  doc.save()
+    .then(() => {
+      sendResponse(res, 200, respBody);
+    })
+    .catch(err => {
+      sendError(res, err, err.message);
+    });
+};
+
+/**
+ * Use the update fields to perform a partial update on the given health subdocument.
+ * 
+ * @param {Subdocument} health Mongoose health subdocument.
+ * @param {Object} updatedFields The collection of updated fields for this health profile.
+ * @returns {Subdocument} The updated health subdocument.
+ */
+const updateHealthFields = (health, updatedFields) => {
+  Object.keys(updatedFields).forEach((key) => {
+    health[key] = updatedFields[key];
+  });
+
+  return health;
+};
+
+module.exports = {
+  healthRouter: router,
+};

--- a/packages/api/routes/reminderTypes.js
+++ b/packages/api/routes/reminderTypes.js
@@ -1,0 +1,351 @@
+const router = require('express').Router();
+const ReminderType = require('../models/ReminderType');
+const User = require('../models/User');
+const { sendResponse, sendError } = require('../util/responses');
+const { authenticateJWT } = require('../middleware/routerMiddleware');
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/reminder-types:
+ *    get:
+ *      security:
+ *        - BearerAuth: []
+ *      tags: [reminders]
+ *      summary: Get reminder types.
+ *      description:  Get all reminder types for the user contained in the required JSON Web Token. 
+ *        This action can only be performed by an authenticated user.
+ *      operationId: getReminderTypes
+ *      responses:
+ *        200:
+ *          description: List of reminder types successfully retrieved.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: array
+ *                items:
+ *                  $ref: '#/components/schemas/ReminderType'
+ *        401:
+ *          $ref: '#/components/responses/401Unauthorized'
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.get('/', authenticateJWT, (req, res) => {
+  const userId = req.tokenPayload.id;
+
+  ReminderType.find({ user: userId })
+    .then(results => {
+      sendResponse(res, 200, results);
+    })
+    .catch(err => {
+      console.log(err);
+      sendError(res, err, err.message);
+    });
+});
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/reminder-types/{reminderTypeId}:
+ *    get:
+ *      security:
+ *        - BearerAuth: []
+ *      tags: [reminders]
+ *      summary: Get reminder type by id.
+ *      description:  Get a single reminder type for the user contained in the required JSON Web Token.
+ *        This action can only be performed by an authenticated user.
+ *      operationId: getReminderType
+ *      parameters:
+ *        - in: path
+ *          name: reminderTypeId
+ *          required: true
+ *          description: The Object Id of the reminder type to be retrieved.
+ *          schema:
+ *            type: string
+ *            format: objectId
+ *          example: 6058319d6aedde248dbad720
+ *      responses:
+ *        200:
+ *          description: Reminder Type successfully retrieved.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                $ref: '#/components/schemas/ReminderType'
+ *        401:
+ *          $ref: '#/components/responses/401Unauthorized'
+ *        403:
+ *          $ref: '#/components/responses/403Forbidden'
+ *        404:
+ *          description: Not found.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  error: 
+ *                    type: string
+ *                    example: Reminder Type with id does not exist.
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.get('/:id', authenticateJWT, async (req, res) => {
+  const { id } = req.params;
+  const userId = req.tokenPayload.id;
+  const reminderType = await ReminderType.findById(id);
+
+  if (reminderType) {
+    if (reminderType.user == userId)
+      sendResponse(res, 200, reminderType);
+    else
+      sendError(res, 403, 'This user is not authorized to perform this action.');
+  } else {
+    sendError(res, 404, `Reminder Type with id ${id} does not exist.`);
+  }
+});
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/reminder-types:
+ *    post:
+ *      security:
+ *        - BearerAuth: []
+ *      tags: [reminders]
+ *      summary: Create reminder type.
+ *      description: Create a new reminder type for the user contained in the required JSON Web Token. 
+ *        This action can only be performed by an authenticated user.
+ *      operationId: createReminderType
+ *      requestBody:
+ *        description: ReminderType
+ *        required: true
+ *        content:
+ *          application/json:
+ *            title: Reminder Type
+ *            type: object
+ *            required:
+ *              - type
+ *            properties:
+ *              type:
+ *                type: string
+ *                example: Class
+ *              color:
+ *                type: string
+ *                example: '#001C5C'
+ *      responses:
+ *        201:
+ *          description: New reminder type successfully created.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: array
+ *                items:
+ *                  $ref: '#/components/schemas/Reminder'
+ *        400:
+ *          $ref: '#/components/responses/400BadRequest'
+ *        401:
+ *          $ref: '#/components/responses/401Unauthorized'
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.post('/', authenticateJWT, async (req, res) => {
+  const userId = req.tokenPayload.id;
+  const newReminderType = req.body;
+
+  newReminderType['user'] = userId;
+
+  ReminderType.create(newReminderType)
+    .then(reminderType => {
+      sendResponse(res, 201, reminderType);
+    })
+    .catch(err => {
+      sendError(res, err, 'The reminder type could not be created.');
+    });
+});
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/reminder-types/{reminderTypeId}:
+ *    put:
+ *      security:
+ *        - BearerAuth: []
+ *      tags: [reminders]
+ *      summary: Update a reminder type.
+ *      description: Update a reminder type for the user contained in the required JSON Web Token. 
+ *        This action can only be performed by an authenticated user.
+ *      operationId: updateReminderType
+ *      parameters:
+ *        - in: path
+ *          name: reminderTypeId
+ *          required: true
+ *          description: The Object Id of the reminder type to be updated.
+ *          schema:
+ *            type: string
+ *            format: objectId
+ *          example: 6058319d6aedde248dbad720
+ *      requestBody:
+ *        description: ReminderType
+ *        required: true
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: '#/components/schemas/ReminderType'
+ *      responses:
+ *        200:
+ *          description: Reminder type successfully updated.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                $ref: '#/components/schemas/ReminderType'
+ *        400:
+ *          $ref: '#/components/responses/400BadRequest'
+ *        401:
+ *          $ref: '#/components/responses/401Unauthorized'
+ *        403:
+ *          $ref: '#/components/responses/403Forbidden'
+ *        404:
+ *          description: Not found.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  error: 
+ *                    type: string
+ *                    example: Reminder Type with id does not exist.
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.put('/:id', authenticateJWT, async (req, res) => {
+  const { id } = req.params;
+  const updatedFields = req.body;
+  const userId = req.tokenPayload.id;
+  const reminderType = await ReminderType.findById(id);
+
+  if (reminderType) {
+    if (reminderType.user == userId) {
+      const updatedReminderType = updateReminderTypeFields(reminderType, updatedFields);
+      save(reminderType, res, updatedReminderType);
+    }
+    else {
+      sendError(res, 403, 'This user is not authorized to perform this action.');
+    }
+  } else {
+    sendError(res, 404, `Reminder Type with id ${id} does not exist.`);
+  }
+});
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/reminder-types/{reminderTypeId}:
+ *    delete:
+ *      security:
+ *        - BearerAuth: []
+ *      tags: [reminders]
+ *      summary: Delete a reminder type.
+ *      description: Delete a reminder type by id for the user contained in the required JSON Web 
+ *        Token. This action can only be performed by an authenticated user.
+ *      operationId: deleteReminder
+ *      parameters:
+ *        - in: path
+ *          name: reminderTypeId
+ *          required: true
+ *          description: The Object Id of the reminder type to be deleted.
+ *          schema:
+ *            type: string
+ *            format: objectId
+ *          example: 6058319d6aedde248dbad720
+ *      responses:
+ *        204:
+ *          description: Reminder type successfully deleted.
+ *        401:
+ *          $ref: '#/components/responses/401Unauthorized'
+ *        403:
+ *          $ref: '#/components/responses/403Forbidden'
+ *        404:
+ *          description: Not found.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  error: 
+ *                    type: string
+ *                    example: Reminder Type with id does not exist.
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.delete('/:id', authenticateJWT, async (req, res) => {
+  const { id } = req.params;
+  const userId = req.tokenPayload.id;
+  const reminderType = await ReminderType.findById(id);
+
+  if (reminderType) {
+    if (reminderType.user == userId) {
+      deleteReminderType(id, res);
+    } else {
+      sendError(res, 403, 'This user is not authorized to perform this action.');
+    }
+  } else {
+    sendError(res, 404, `Reminder Type with id ${id} does not exist.`);
+  }
+});
+
+/**
+ * Delete the remainder type with the given id.
+ * 
+ * @param {String} id Reminder type object id.
+ * @param {Object} resp Express response object.
+ */
+const deleteReminderType = (id, res) => {
+  ReminderType.findByIdAndRemove({ _id: id })
+    .then(() => {
+      sendResponse(res, 204, {});
+    })
+    .catch(err => {
+      sendError(res, err, `The reminder type with id ${id} could not be removed.`);
+    });
+};
+
+/**
+ * Save the document and send an OK response. If the document does not validate, abort and send
+ * error HTTP response.
+ * 
+ * @param {Document} doc Mongoose document.
+ * @param {Object} res Express response object.
+ * @param {Object} respBody Response body for the OK HTTP response.
+ */
+const save = (doc, res, respBody) => {
+  doc.save()
+    .then(() => {
+      sendResponse(res, 200, respBody);
+    })
+    .catch(err => {
+      sendError(res, err, err.message);
+    });
+};
+
+/**
+ * Use the update fields to perform a partial update on the given reminder type subdocument.
+ * 
+ * @param {Subdocument} reminderType Mongoose reminder type subdocument.
+ * @param {Object} updatedFields The collection of updated fields for this reminder type.
+ * @returns {Subdocument} The updated reminder type subdocument.
+ */
+const updateReminderTypeFields = (reminderType, updatedFields) => {
+  Object.keys(updatedFields).forEach((key) => {
+    reminderType[key] = updatedFields[key];
+  });
+
+  return reminderType;
+};
+
+module.exports = {
+  reminderTypeRouter: router,
+};

--- a/packages/api/routes/reminders.js
+++ b/packages/api/routes/reminders.js
@@ -1,0 +1,346 @@
+const router = require('express').Router();
+const User = require('../models/User');
+const { sendResponse, sendError } = require('../util/responses');
+const { authenticateJWT } = require('../middleware/routerMiddleware');
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/reminders:
+ *    get:
+ *      security:
+ *        - BearerAuth: []
+ *      tags: [reminders]
+ *      summary: Get reminders.
+ *      description:  Get all reminders for the user contained in the required JSON Web Token. This 
+ *        action can only be performed by an authenticated user.
+ *      operationId: getReminders
+ *      responses:
+ *        200:
+ *          description: List of reminders successfully retrieved.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: array
+ *                items:
+ *                  $ref: '#/components/schemas/Reminder'
+ *        401:
+ *          $ref: '#/components/responses/401Unauthorized'
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.get('/', authenticateJWT, (req, res) => {
+  const userId = req.tokenPayload.id;
+
+  User.findById(userId, 'reminders')
+    .then(results => {
+      sendResponse(res, 200, results.reminders);
+    })
+    .catch(err => {
+      sendError(res, err, err.message);
+    });
+});
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/reminders/{reminderId}:
+ *    get:
+ *      security:
+ *        - BearerAuth: []
+ *      tags: [reminders]
+ *      summary: Get reminder by id.
+ *      description:  Get a single reminder for the user contained in the required JSON Web Token.
+ *        This action can only be performed by an authenticated user.
+ *      operationId: getReminder
+ *      parameters:
+ *        - in: path
+ *          name: reminderId
+ *          required: true
+ *          description: The Object Id of the reminder to be retrieved.
+ *          schema:
+ *            type: string
+ *            format: objectId
+ *          example: 6058319d6aedde248dbad720
+ *      responses:
+ *        200:
+ *          description: Reminder successfully retrieved.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                $ref: '#/components/schemas/Reminder'
+ *        404:
+ *          description: Not found.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  error: 
+ *                    type: string
+ *                    example: Reminder with id does not exist.
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.get('/:id', authenticateJWT, (req, res) => {
+  const { id } = req.params;
+  const userId = req.tokenPayload.id;
+
+  User.findById(userId)
+    .then(user => {
+      const reminder = user.reminders.id(id);
+      
+      if (reminder)
+        sendResponse(res, 200, reminder);
+      else
+        sendError(res, 404, `Reminder with id ${id} does not exist.`);
+    })
+    .catch(err => {
+      sendError(res, err, err.message);
+    });
+});
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/reminders:
+ *    post:
+ *      security:
+ *        - BearerAuth: []
+ *      tags: [reminders]
+ *      summary: Create reminder.
+ *      description: Create a new reminder for the user contained in the required JSON Web Token. 
+ *        This action can only be performed by an authenticated user.
+ *      operationId: createReminder
+ *      requestBody:
+ *        description: Reminder
+ *        required: true
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: '#/components/schemas/Reminder'
+ *      responses:
+ *        201:
+ *          description: New reminder successfully created.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: array
+ *                items:
+ *                  $ref: '#/components/schemas/Reminder'
+ *        400:
+ *          $ref: '#/components/responses/400BadRequest'
+ *        401:
+ *          $ref: '#/components/responses/401Unauthorized'
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.post('/', authenticateJWT, async (req, res) => {
+  const userId = req.tokenPayload.id;
+  const newReminder = req.body;
+  const user = await User.findById(userId);
+
+  if (user) {
+    user.reminders.push(newReminder);
+    user.save()
+      .then(updatedUser => {
+        sendResponse(res, 201, updatedUser.reminders);
+      })
+      .catch(err => {
+        sendError(res, err, err.message);
+      });
+  } else {
+    sendError(res, 500, 'Server failed to fetch this user.');
+  }
+});
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/reminders/{reminderId}:
+ *    put:
+ *      security:
+ *        - BearerAuth: []
+ *      tags: [reminders]
+ *      summary: Update a reminder.
+ *      description: Update a reminder for the user contained in the required JSON Web Token. This 
+ *        action can only be performed by an authenticated user.
+ *      operationId: updateReminder
+ *      parameters:
+ *        - in: path
+ *          name: reminderId
+ *          required: true
+ *          description: The Object Id of the reminder to be updated.
+ *          schema:
+ *            type: string
+ *            format: objectId
+ *          example: 6058319d6aedde248dbad720
+ *      requestBody:
+ *        description: Reminder
+ *        required: true
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: '#/components/schemas/Reminder'
+ *      responses:
+ *        200:
+ *          description: Reminder successfully updated.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                $ref: '#/components/schemas/Reminder'
+ *        400:
+ *          $ref: '#/components/responses/400BadRequest'
+ *        401:
+ *          $ref: '#/components/responses/401Unauthorized'
+ *        404:
+ *          description: Not found.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  error: 
+ *                    type: string
+ *                    example: Reminder with id does not exist.
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.put('/:id', authenticateJWT, async (req, res) => {
+  const { id } = req.params;
+  const updatedFields = req.body;
+  const userId = req.tokenPayload.id;
+  const user = await User.findById(userId);
+
+  if (user) {
+    const reminder = user.reminders.id(id);
+
+    if (reminder) {
+      const updatedReminder = updateReminderFields(reminder, updatedFields);
+      save(user, res, updatedReminder);
+    } else {
+      sendError(res, 404, `Reminder with id ${id} does not exist.`);
+    }
+  } else {
+    sendError(res, 500, 'Server failed to fetch this user.');
+  }
+});
+
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/reminders/{reminderId}:
+ *    delete:
+ *      security:
+ *        - BearerAuth: []
+ *      tags: [reminders]
+ *      summary: Delete a reminder.
+ *      description: Delete a reminder by id for the user contained in the required JSON Web Token.
+ *        This action can only be performed by an authenticated user.
+ *      operationId: deleteReminder
+ *      parameters:
+ *        - in: path
+ *          name: reminderId
+ *          required: true
+ *          description: The Object Id of the reminder to be deleted.
+ *          schema:
+ *            type: string
+ *            format: objectId
+ *          example: 6058319d6aedde248dbad720
+ *      responses:
+ *        204:
+ *          description: Reminder successfully deleted.
+ *        401:
+ *          $ref: '#/components/responses/401Unauthorized'
+ *        404:
+ *          description: Not found.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  error: 
+ *                    type: string
+ *                    example: Reminder with id does not exist.
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.delete('/:id', authenticateJWT, async (req, res) => {
+  const { id } = req.params;
+  const userId = req.tokenPayload.id;
+  const user = await User.findById(userId);
+
+  if (user) {
+    deleteReminder(user, id, resp);
+  } else {
+    sendError(res, 500, 'Server failed to fetch this user.');
+  }
+});
+
+/**
+ * Delete the remainder with the given id from the user document.
+ * 
+ * @param {Document} user Mongoose user document.
+ * @param {String} reminderId Reminder Object Id.
+ * @param {Object} resp Express response object.
+ */
+const deleteReminder = (user, reminderId, resp) => {
+  const reminder = user.reminders.id(reminderId);
+
+  if (reminder) {
+    reminder.remove();
+
+    user.save()
+      .then(() => {
+        sendResponse(res, 204, {});
+      })
+      .catch((err) => {
+        sendError(res, err, err.message);
+      });
+  } else {
+    sendError(res, 404, `Reminder with id ${reminderId} does not exist.`);
+  }
+};
+
+/**
+ * Use the update fields to perform a partial update on the given reminder subdocument.
+ * 
+ * @param {Subdocument} reminder Mongoose reminder subdocument.
+ * @param {Object} updatedFields The collection of updated fields for this reminder.
+ * @returns {Subdocument} The updated reminder subdocument.
+ */
+const updateReminderFields = (reminder, updatedFields) => {
+  Object.keys(updatedFields).forEach((key) => {
+    reminder[key] = updatedFields[key];
+  });
+
+  return reminder;
+};
+
+/**
+ * Save the document and send an OK response. If the document does not validate, abort and send
+ * error HTTP response.
+ * 
+ * @param {Document} doc Mongoose document.
+ * @param {Object} res Express response object.
+ * @param {Object} respBody Response body for the OK HTTP response.
+ */
+const save = (doc, res, respBody) => {
+  doc.save()
+    .then(() => {
+      sendResponse(res, 200, respBody);
+    })
+    .catch(err => {
+      sendError(res, err, err.message);
+    });
+};
+
+module.exports = {
+  reminderRouter: router,
+}

--- a/packages/api/routes/routes.js
+++ b/packages/api/routes/routes.js
@@ -19,20 +19,20 @@ module.exports = {
       res.send('{"message": "LYFE API"}');
     });
 
-    // In production redirect all other routes to the client home.
-    if (NODE_ENV === 'production') {
-      server.get('*', (req, res) => {
-        res.sendFile(
-          path.resolve(__dirname, '../../client/build', 'index.html')
-        );
-      });
-    } else {
-      server.get('*', (req, res) => {
-        res.set('Content-Type', 'application/json');
-        res.send(
-          '{"message": "In production this action will result in a redirect to the client."}'
-        );
-      });
-    }
+    // // In production redirect all other routes to the client home.
+    // if (NODE_ENV === 'production') {
+    //   server.get('*', (req, res) => {
+    //     res.sendFile(
+    //       path.resolve(__dirname, '../../client/build', 'index.html')
+    //     );
+    //   });
+    // } else {
+    //   server.get('*', (req, res) => {
+    //     res.set('Content-Type', 'application/json');
+    //     res.send(
+    //       '{"message": "In production this action will result in a redirect to the client."}'
+    //     );
+    //   });
+    // }
   },
 };

--- a/packages/api/routes/routes.js
+++ b/packages/api/routes/routes.js
@@ -1,11 +1,17 @@
 require('dotenv').config();
 
 const path = require('path');
+const { healthRouter } = require('./health');
+const { reminderRouter } = require('./reminders');
+const { reminderTypeRouter } = require('./reminderTypes');
 const { userRouter } = require('./users');
 const { NODE_ENV } = process.env;
 
 module.exports = {
   routes: (server) => {
+    server.use('/api/health', healthRouter);
+    server.use('/api/reminders', reminderRouter);
+    server.use('/api/reminder-types', reminderTypeRouter);
     server.use('/api/users', userRouter);
 
     server.get('/api', (req, res) => {

--- a/packages/api/routes/routes.js
+++ b/packages/api/routes/routes.js
@@ -19,20 +19,20 @@ module.exports = {
       res.send('{"message": "LYFE API"}');
     });
 
-    // // In production redirect all other routes to the client home.
-    // if (NODE_ENV === 'production') {
-    //   server.get('*', (req, res) => {
-    //     res.sendFile(
-    //       path.resolve(__dirname, '../../client/build', 'index.html')
-    //     );
-    //   });
-    // } else {
-    //   server.get('*', (req, res) => {
-    //     res.set('Content-Type', 'application/json');
-    //     res.send(
-    //       '{"message": "In production this action will result in a redirect to the client."}'
-    //     );
-    //   });
-    // }
+    // In production redirect all other routes to the client home.
+    if (NODE_ENV === 'production') {
+      server.get('*', (req, res) => {
+        res.sendFile(
+          path.resolve(__dirname, '../../client/build', 'index.html')
+        );
+      });
+    } else {
+      server.get('*', (req, res) => {
+        res.set('Content-Type', 'application/json');
+        res.send(
+          '{"message": "In production this action will result in a redirect to the client."}'
+        );
+      });
+    }
   },
 };

--- a/packages/api/routes/users.js
+++ b/packages/api/routes/users.js
@@ -74,7 +74,7 @@ router.post('/register', (req, res) => {
           sendVerificationEmail(user, updatedUser.verificationToken, res);
         })
         .catch(err => {
-          sendError(res, '500', 'User registered but verification token could not be generated.');
+          sendError(res, 500, 'User registered but verification token could not be generated.');
         });
     })
     .catch((err) => {
@@ -150,7 +150,7 @@ router.post('/verify/resend', async (req, res) => {
         sendVerificationEmail(updatedUser, updatedUser.verificationToken, res);
       })
       .catch(err => {
-        sendError(res, '500', 'Server failed to send verification email.');
+        sendError(res, 500, 'Server failed to send verification email.');
       });
   }
 });
@@ -231,9 +231,9 @@ router.post('/verify/:token', async (req, res) => {
     if (user)
       verifyUser(user, password, res);
     else 
-      sendError(res, '401', 'Token and/or password is not associated with any registered account.');
+      sendError(res, 401, 'Token and/or password is not associated with any registered account.');
   } else {
-    sendError(res, '400', 'Token and password are required.');
+    sendError(res, 400, 'Token and password are required.');
   }
 });
 
@@ -243,7 +243,7 @@ router.post('/login', (req, res) => {
   if (hasLoginCredentials(email, password)) {
     findUser(req, res);
   } else {
-    sendError(res, '400', 'Email and password are required.');
+    sendError(res, 400, 'Email and password are required.');
   }
 });
 
@@ -483,7 +483,7 @@ router.delete('/:id', authenticateJWT, (req, res) => {
         sendError(res, err, `The user with id ${id} could not be removed.`);
       });
   } else {
-    sendError(res, '403', 'This user is not authorized to perform this action.');
+    sendError(res, 403, 'This user is not authorized to perform this action.');
   }
 });
 
@@ -520,10 +520,10 @@ const isVerifiable = (user, res) => {
   let verifiable = true;
 
   if (!user) {
-    sendError(res, '401', `Email is not associated with any registered account.`);
+    sendError(res, 401, `Email is not associated with any registered account.`);
     verifiable = false;
   } else if (user.verified) {
-    sendError(res, '400', 'This user is already verified.');
+    sendError(res, 400, 'This user is already verified.');
     verifiable = false;
   }
 
@@ -545,7 +545,7 @@ const findUser = (req, res) => {
       if (user) {
         validatePassword(user, password, res);
       } else {
-        sendError(res, '401', 'Email and/or password is incorrect.');
+        sendError(res, 401, 'Email and/or password is incorrect.');
       }
     })
     .catch((err) => {
@@ -566,10 +566,10 @@ const verifyUser = async (user, password, res) => {
   const result = await user.isValidPassword(password);
   
   if (!result)
-    return sendError(res, '401', 'Invalid password.');
+    return sendError(res, 401, 'Invalid password.');
 
   if (user.verified)
-    return sendError(res, '400', 'This user is already verified');
+    return sendError(res, 400, 'This user is already verified');
 
   setVerificationStatus(user, true, res);
 };
@@ -586,10 +586,10 @@ const validatePassword = (user, password, res) => {
   user.isValidPassword(password)
     .then((result) => {
       if (!result)
-        return sendError(res, '401', 'Email and/or password is incorrect.');
+        return sendError(res, 401, 'Email and/or password is incorrect.');
       
       const token = user.generateJWT();
-      sendResponse(res, '201', { token });
+      sendResponse(res, 201, { token });
     });
 };
 
@@ -654,7 +654,7 @@ const sendVerificationEmail = (user, token, res) => {
       });
     })
     .catch(err => {
-      sendError(res, '500', 'Server failed to send verification email.');
+      sendError(res, 500, 'Server failed to send verification email.');
     });
 };
 

--- a/packages/api/routes/users.js
+++ b/packages/api/routes/users.js
@@ -68,7 +68,7 @@ router.post('/register', (req, res) => {
   const newUser = req.body;
 
   User.create(newUser)
-    .then((user) => {
+    .then(user => {
       user.generateVerificationToken()
         .then(updatedUser => {
           sendVerificationEmail(user, updatedUser.verificationToken, res);
@@ -448,7 +448,7 @@ router.get('/reset/:token', (req, res) => {
  *        - BearerAuth: []
  *      tags: [users]
  *      summary: Delete a user.
- *      description: Deletes a user by id. This action can only be performed by an authenticated 
+ *      description: Delete a user by id. This action can only be performed by an authenticated 
  *        user and users may only delete their own account.
  *      operationId: deleteUser
  *      parameters:
@@ -461,17 +461,8 @@ router.get('/reset/:token', (req, res) => {
  *            format: objectId
  *          example: 6058319d6aedde248dbad720
  *      responses:
- *        200:
- *          description: User deleted successfully.
- *          content: 
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                  _id: 
- *                    type: string
- *                    format: objectId
- *                    example: 6058319d6aedde248dbad720
+ *        204:
+ *          description: User successfully deleted.
  *        401:
  *          $ref: '#/components/responses/401Unauthorized'
  *        403:
@@ -481,12 +472,12 @@ router.get('/reset/:token', (req, res) => {
  */
 router.delete('/:id', authenticateJWT, (req, res) => {
   const { id } = req.params;
-  const thisUser = req.tokenPayload.id;
+  const userId = req.tokenPayload.id;
 
-  if (thisUser === id) {
+  if (userId === id) {
     User.findByIdAndRemove({ _id: id })
       .then(({ _id }) => {
-        sendResponse(res, '200', { _id: _id });
+        sendResponse(res, 204, {});
       })
       .catch((err) => {
         sendError(res, err, `The user with id ${id} could not be removed.`);
@@ -501,7 +492,7 @@ router.delete('/:id', authenticateJWT, (req, res) => {
  * 
  * @param {String} email The user's email address. 
  * @param {String} password The user's password.
- * @returns 
+ * @returns {Boolean} Whether or not both the email and password are present.
  */
 const hasLoginCredentials = (email, password) => {
   return email && password; 
@@ -512,7 +503,7 @@ const hasLoginCredentials = (email, password) => {
  * 
  * @param {String} token A token.
  * @param {String} password The user's password.
- * @returns 
+ * @returns {Boolean} Whether or not both the token and password are present.
  */
 const hasTokenCredentials = (token, password) => {
   return token && password;
@@ -523,6 +514,7 @@ const hasTokenCredentials = (token, password) => {
  * 
  * @param {Document} user Mongoose user document.
  * @param {Object} res Express response object.
+ * @returns {Boolean} Whether or not the user can request a verification email.
  */
 const isVerifiable = (user, res) => {
   let verifiable = true;
@@ -568,7 +560,7 @@ const findUser = (req, res) => {
  * @param {Document} user Mongoose user document.
  * @param {String} password The user's password.
  * @param {Object} res Express response object.
- * @returns 
+ * @returns {Undefined} Return used eto end function early.
  */
 const verifyUser = async (user, password, res) => {
   const result = await user.isValidPassword(password);

--- a/packages/api/routes/users.js
+++ b/packages/api/routes/users.js
@@ -1,11 +1,14 @@
 /**
  * @todo: complete openapi specs for login
  */
+require('dotenv').config();
 
 const router = require('express').Router();
 const User = require('../models/User');
 const { sendResponse, sendError } = require('../util/responses');
-const { generateJWT, authenticateJWT } = require('../middleware/routerMiddleware');
+const { authenticateJWT } = require('../middleware/routerMiddleware');
+const { sendEmail } = require('../util/mailer');
+const { APP_URL } = process.env;
 
 /**
  * @openapi
@@ -15,7 +18,7 @@ const { generateJWT, authenticateJWT } = require('../middleware/routerMiddleware
  *    post:
  *      tags: [users]
  *      summary: Create a new user.
- *      description: Creates a new user and returns a signed JSON Web Token.
+ *      description: Creates a new unverified user and triggers email verification.
  *      operationId: createUser
  *      requestBody:
  *        description: User to create.
@@ -23,19 +26,38 @@ const { generateJWT, authenticateJWT } = require('../middleware/routerMiddleware
  *        content: 
  *          application/json:
  *            schema: 
- *              $ref: '#/components/schemas/User'
+ *              title: Unverified User
+ *              type: object
+ *              required:
+ *                - firstName
+ *                - lastName
+ *                - email
+ *                - password
+ *              properties:
+ *                firstName:
+ *                  type: string
+ *                  example: John
+ *                lastName:
+ *                  type: string
+ *                  example: Smith
+ *                email:
+ *                  type: string
+ *                  format: email
+ *                password:
+ *                  type: string
+ *                  format: password
+ *                  example: Password123#
  *      responses:
- *        201:
- *          description: New user created.
+ *        200:
+ *          description: New user created and verification email requested.
  *          content:
  *            application/json:
  *              schema:
  *                type: object
  *                properties:
- *                  token:
- *                    type: string
- *                    format: jsonWebToken
- *                    example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYwNTgzMTlkNmFlZGRlMjQ4ZGJhZDcyMCIsImlhdCI6MTYxNjY1ODIwMSwiZXhwIjoxNjE2NjYxODAxfQ.xicZukmEjma0owGMY06ZFrsaemtHOkop8BSPC2arB3k
+ *                  message:
+ *                    type: String
+ *                    example: Requested verification email. Check email for verification code.
  *        400:
  *          $ref: '#/components/responses/400BadRequest'
  *        500:
@@ -45,20 +67,179 @@ router.post('/register', (req, res) => {
   const newUser = req.body;
 
   User.create(newUser)
-    .then(({ _id }) => {
-      const token = generateJWT({ id: _id });
-      sendResponse(res, 201, { token });
+    .then((user) => {
+      user.generateVerificationToken()
+        .then(updatedUser => {
+          sendVerificationEmail(user, updatedUser.verificationToken, res);
+        })
+        .catch(err => {
+          sendError(res, '500', 'User registered but verification token could not be generated.');
+        });
     })
     .catch((err) => {
       sendError(res, err, 'The user could not be created.');
     });
 });
 
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/users/verify/resend:
+ *    post:
+ *      tags: [users]
+ *      summary: Resend verification email.
+ *      description: Request another verification email be sent to this user.
+ *      operationId: resendVerificationEmail
+ *      requestBody:
+ *        description: User's email address.
+ *        required: true
+ *        content:
+ *          application/json:
+ *            schema:
+ *              title: Email Address
+ *              type: object
+ *              required:
+ *                - email
+ *              properties:
+ *                email:
+ *                  type: string
+ *                  format: email
+ *      responses:
+ *        200:
+ *          description: Resent verification email.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  message:
+ *                    type: String
+ *                    example: Requested verification email. Check email for verification code.
+ *        400:
+ *          description: Bad request.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  message:
+ *                    type: String
+ *                    example: This user is already verified.
+ *        401:
+ *          description: Unauthorized.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  message:
+ *                    type: String
+ *                    example: Email is not associated with any registered account.
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.post('/verify/resend', async (req, res) => {
+  const { email } = req.body;
+  const user = await User.findOne({ email });
+  
+  if (isVerifiable(user, res)) {
+    user.generateVerificationToken()
+      .then(updatedUser => {
+        sendVerificationEmail(user, updatedUser.verificationToken, res);
+      })
+      .catch(err => {
+        sendError(res, '500', 'Server failed to send verification email.');
+      });
+  }
+});
+
+/**
+ * @openapi
+ * 
+ * paths:
+ *  /api/users/verify/{token}:
+ *    post:
+ *      tags: [users]
+ *      summary: Verify email.
+ *      description: Verify this user's email address.
+ *      operationId: verifyEmail
+ *      parameters:
+ *        - in: path
+ *          name: token
+ *          required: true
+ *          description: Email verification token.
+ *          schema:
+ *            type: string
+ *          example: 0105274e7e458208977c28bfdf11ddf05b5e0ab54b60cc70666736a030a153b0
+ *      requestBody:
+ *        description: User's password.
+ *        required: true
+ *        content:
+ *          application/json:
+ *            schema:
+ *              title: Password
+ *              type: object
+ *              required:
+ *                - password
+ *              properties:
+ *                password:
+ *                  type: string
+ *                  example: Password123#
+ *      responses:
+ *        200:
+ *          description: User verified.
+ *          content: 
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  token: 
+ *                    type: string
+ *                    example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYwNWM1ZmNkYTdjYzQ0MzE2NTE2NjAwNiIsImlhdCI6MTYxNzI2MDY2OSwiZXhwIjoxNjE3MjY0MjY5fQ.GTR5Lzeeo-T2fb0AA0pISZ05z36NtAgPGFeMYliBHQA
+ *        400:
+ *          description: Bad request.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  message:
+ *                    type: string
+ *                    example: This user is already verified.
+ *        401:
+ *          description: Unauthorized.
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  message:
+ *                    type: string
+ *                    example: Token and/or password is not associated with any registered account.
+ *        500:
+ *          $ref: '#/components/responses/500InternalServerError'
+ */
+router.post('/verify/:token', async (req, res) => {
+  const { token } = req.params;
+  const { password } = req.body;
+
+  if (hasVerificationCredentials(token, password)) {
+    const user = await User.findOne({ verificationToken: token });
+
+    if (user)
+      verifyUser(user, password, res);
+    else 
+      sendError(res, '401', 'Token and/or password is not associated with any registered account.');
+  } else {
+    sendError(res, '400', 'Token and password are required.');
+  }
+});
 
 router.post('/login', (req, res) => {
   const { email, password } = req.body;
 
-  if (hasCredentials(email, password)) {
+  if (hasLoginCredentials(email, password)) {
     findUser(req, res);
   } else {
     sendError(res, '400', 'Email and password are required.');
@@ -126,12 +307,43 @@ router.delete('/:id', authenticateJWT, (req, res) => {
 /**
  * Verify that both an email and password are present.
  * 
- * @param {Strin} email The user's email address. 
+ * @param {String} email The user's email address. 
  * @param {String} password The user's password.
  * @returns 
  */
-const hasCredentials = (email, password) => {
+const hasLoginCredentials = (email, password) => {
   return email && password; 
+};
+
+/**
+ * Verify that both a token and password are present.
+ * 
+ * @param {String} token A verification token.
+ * @param {String} password The user's password.
+ * @returns 
+ */
+const hasVerificationCredentials = (token, password) => {
+  return token && password;
+};
+
+/**
+ * Check that this user can request a new verification email.
+ * 
+ * @param {Document} user Mongoose user document.
+ * @param {Object} res Express response object.
+ */
+const isVerifiable = (user, res) => {
+  let verifiable = true;
+
+  if (!user) {
+    sendError(res, '401', `Email is not associated with any registered account.`);
+    verifiable = false;
+  } else if (user.verified) {
+    sendError(res, '400', 'This user is already verified.');
+    verifiable = false;
+  }
+
+  return verifiable;
 };
 
 /**
@@ -158,6 +370,27 @@ const findUser = (req, res) => {
 };
 
 /**
+ * Check that the user can update their verification status. If so call function to set status to
+ * true.
+ * 
+ * @param {Document} user Mongoose user document.
+ * @param {String} password The user's password.
+ * @param {Object} res Express response object.
+ * @returns 
+ */
+const verifyUser = async (user, password, res) => {
+  const result = await user.isValidPassword(password);
+  
+  if (!result)
+    return sendError(res, '401', 'Invalid password.');
+
+  if (user.verified)
+    return sendError(res, '400', 'This user is already verified');
+
+  setVerificationStatus(user, true, res);
+};
+
+/**
  * Validate the password. Verify that it matches the password saved for this user. If it matches,
  * generate and return a JWT. Otherwise, send a bad request response.
  * 
@@ -171,8 +404,53 @@ const validatePassword = (user, password, res) => {
       if (!result)
         return sendError(res, '401', 'Email and/or password is incorrect.');
       
-      const token = generateJWT({ id: user._id });
-      sendResponse(res, 201, { token });
+      const token = user.generateJWT();
+      sendResponse(res, '201', { token });
+    });
+};
+
+/**
+ * 
+ * @param {Document} user Mongoose user document.
+ * @param {Boolean} status Verification status.
+ * @param {Object} res Express response object.
+ */
+const setVerificationStatus = (user, status, res) => {
+  user.verified = status;
+  user.save()
+    .then(updatedUser => {
+      const token = updatedUser.generateJWT();
+      sendResponse(res, 200, { token });
+    })
+    .catch(err => {
+      sendError(res, err, err.message);
+    });
+};
+
+/**
+ * Construct a verification email and request that it be sent through the mailer sendMail helper.
+ * 
+ * @param {Document} user Mongoose user document.
+ * @param {String} token The verification token.
+ * @param {Object} res Express response object.
+ */
+const sendVerificationEmail = (user, token, res) => {
+  const verificationLink = `${APP_URL}/verify/${token}`;
+  const emailBody = `<p>Hi ${user.firstName} ${user.lastName},</p><br>
+                        <p>Please verify your email address by clicking the link below.</p>
+                        <strong><a href="${verificationLink}" alt="Verify My Email">Verify My Email</a></strong>
+                        <p>If you cannot click on the link, copy and paste the following URL into a new tab in your browser:</p>
+                        <p>${verificationLink}</p><br>
+                        <p>The LYFE Team</p>`;
+
+  sendEmail(user.email, 'Please Verify Your Email', emailBody)
+    .then(result => {
+      sendResponse(res, 200, {
+        message: 'Requested verification email. Check email for verification code.',
+      });
+    })
+    .catch(err => {
+      sendError(res, '500', 'Server failed to send verification email.');
     });
 };
 

--- a/packages/api/server.js
+++ b/packages/api/server.js
@@ -10,25 +10,25 @@ const { MONGODB_URI, PORT } = process.env;
 // Apply server level middleware.
 setupMiddleware(server);
 
-// // Setup api documentation.
-// setupDocs(server);
+// Setup api documentation.
+setupDocs(server);
 
-// // Setup api routes.
-// setupRoutes(server);
+// Setup api routes.
+setupRoutes(server);
 
-// // Setup database connection.
-// mongoose
-//   .connect(MONGODB_URI, {
-//     useNewUrlParser: true,
-//     useUnifiedTopology: true,
-//     useCreateIndex: true,
-//   })
-//   .then(() => {
-//     console.log(`\n*** Connected to database ${MONGODB_URI} ***\n`);
+// Setup database connection.
+mongoose
+  .connect(MONGODB_URI, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+    useCreateIndex: true,
+  })
+  .then(() => {
+    console.log(`\n*** Connected to database ${MONGODB_URI} ***\n`);
     server.listen(PORT, () => {
       console.log(`\n*** Server listening on port ${PORT} ***\n`);
     });
-//   })
-//   .catch((err) => {
-//     console.log('\n*** Error connecting to database ***\n', err);
-//   });
+  })
+  .catch((err) => {
+    console.log('\n*** Error connecting to database ***\n', err);
+  });

--- a/packages/api/server.js
+++ b/packages/api/server.js
@@ -10,25 +10,25 @@ const { MONGODB_URI, PORT } = process.env;
 // Apply server level middleware.
 setupMiddleware(server);
 
-// Setup api documentation.
-setupDocs(server);
+// // Setup api documentation.
+// setupDocs(server);
 
-// Setup api routes.
-setupRoutes(server);
+// // Setup api routes.
+// setupRoutes(server);
 
-// Setup database connection.
-mongoose
-  .connect(MONGODB_URI, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-    useCreateIndex: true,
-  })
-  .then(() => {
-    console.log(`\n*** Connected to database ${MONGODB_URI} ***\n`);
+// // Setup database connection.
+// mongoose
+//   .connect(MONGODB_URI, {
+//     useNewUrlParser: true,
+//     useUnifiedTopology: true,
+//     useCreateIndex: true,
+//   })
+//   .then(() => {
+//     console.log(`\n*** Connected to database ${MONGODB_URI} ***\n`);
     server.listen(PORT, () => {
       console.log(`\n*** Server listening on port ${PORT} ***\n`);
     });
-  })
-  .catch((err) => {
-    console.log('\n*** Error connecting to database ***\n', err);
-  });
+//   })
+//   .catch((err) => {
+//     console.log('\n*** Error connecting to database ***\n', err);
+//   });

--- a/packages/api/util/mailer.js
+++ b/packages/api/util/mailer.js
@@ -1,0 +1,28 @@
+require('dotenv').config();
+
+const sgMail = require('@sendgrid/mail');
+const { SENDGRID_API_KEY, FROM_EMAIL } = process.env;
+
+/**
+ * Send an email through SendGrid's API mail endpoint.
+ * 
+ * @param {String} to The recipient's email address.
+ * @param {String} subject The email subject.
+ * @param {String} body The contents of the email. May be HTML formatted.
+ * @returns {Promise} The pending email request.
+ */
+const sendEmail = (to, subject, body) => {
+  const msg = {
+    to: to,
+    from: FROM_EMAIL,
+    subject: subject,
+    html: body,
+  };
+
+  sgMail.setApiKey(SENDGRID_API_KEY);
+  return sgMail.send(msg);
+};
+
+module.exports = {
+  sendEmail,
+};

--- a/packages/api/util/queries.js
+++ b/packages/api/util/queries.js
@@ -1,0 +1,19 @@
+/**
+ * Perform a partial update on the document with the given fields. Must call save for changes to
+ * persist.
+ *
+ * @param {Document|Subdocument} doc Mongoose document or subdocument.
+ * @param {Object} fields The collection of updated fields for this document.
+ * @returns {Document|Subdocument} The updated document.
+ */
+const partialUpdate = (doc, fields) => {
+  Object.keys(fields).forEach((key) => {
+    doc[key] = fields[key];
+  });
+
+  return doc;
+};
+
+module.exports = {
+  partialUpdate,
+};

--- a/packages/api/util/responses.js
+++ b/packages/api/util/responses.js
@@ -1,8 +1,8 @@
-const HTTP_STATUS_CODES = ['201', '400', '401', '403', '404', '500']
+const HTTP_STATUS_CODES = ['201', '400', '401', '403', '404', '500'];
 
 /**
  * Format and send an HTTP response.
- * 
+ *
  * @param {Object} res Express response object.
  * @param {Integer} status HTTP status code.
  * @param {Object} data JSON body.
@@ -13,8 +13,65 @@ const sendResponse = (res, status, data) => {
 };
 
 /**
- * Format and send an error HTTP response.
+ * @openapi
  * 
+ * components:
+ *  responses:
+ *    400BadRequest:
+ *      description: Bad Request.
+ *      content:
+ *        application/json:
+ *          schema:
+ *            type: object
+ *            properties:
+ *              error:
+ *                type: string
+ *                example: "Validation failed: {Additional details}"
+ *    401Unauthorized:
+ *      description: Unauthorized.
+ *      content:
+ *        application/json:
+ *          schema:
+ *            type: object
+ *            properties:
+ *              error:
+ *                type: string
+ *                example: Access denied. This request requires user authentication.
+ *    403Forbidden:
+ *      description: Forbidden.
+ *      content:
+ *        application/json:
+ *          schema:
+ *            type: object
+ *            properties:
+ *              error:
+ *                type: string
+ *                example: This user is not authorized to perform this action.
+ *    404NotFound:
+ *      description: Not Found.
+ *      content:
+ *        application/json:
+ *          schema:
+ *            type: object
+ *            properties:
+ *              error:
+ *                type: string
+ *                example: The document with the given ID does not exist.
+ *    500InternalServerError:
+ *      description: Internal server error.
+ *      content:
+ *        application/json:
+ *          schema:
+ *            type: object
+ *            properties:
+ *              error:
+ *                type: string
+ *                example: This action could not be completed.
+ */
+
+/**
+ * Format and send an error HTTP response.
+ *
  * @param {Object} res Express response object.
  * @param {Object|String} err Error object or HTTP status code.
  * @param {String} message User friendly message to send on response object.
@@ -29,25 +86,23 @@ const sendError = (res, err, message) => {
 
 /**
  * Get and return the correct HTTP status code.
- * 
+ *
  * @param {Object|String} err Error object or HTTP status code.
  * @returns {Integer} The HTTP status code.
  */
 const getStatusCode = (err) => {
   let statusCode = 500;
 
-  if (err.name === 'ValidationError') statusCode = 400;
+  if (err.name === 'ValidationError' || err.code === 11000) statusCode = 400;
   if (err.name === 'CastError') statusCode = 404;
-  
-  if (HTTP_STATUS_CODES.includes(err))
-    statusCode = parseInt(err);
+  if (HTTP_STATUS_CODES.includes(err)) statusCode = parseInt(err);
 
   return statusCode;
 };
 
 /**
  * Construct JSON body for HTTP error response.
- * 
+ *
  * @param {Object|String} err Error object or HTTP status code.
  * @param {String} msg User friendly message to send on response object.
  * @returns {Object} JSON body.
@@ -55,12 +110,18 @@ const getStatusCode = (err) => {
 const getErrorJson = (err, msg) => {
   let errMsg = msg;
 
-  if (err.name === 'ValidationError')
-    errMsg = err.message;
-  
-  if (err.name === 'CastError')
-    errMsg = 'The document with the specified ID does not exist.';
+  if (err.name === 'ValidationError') errMsg = err.message;
 
+  if (err.name === 'CastError')
+    errMsg = 'The document with the given ID does not exist.';
+
+  if (err.code === 11000) {
+    errMsg = '';
+
+    for (let key in err.keyValue)
+      errMsg += `Duplicate Key: ${key} is already taken.`;
+  }
+    
   return { error: errMsg };
 };
 

--- a/packages/api/util/responses.js
+++ b/packages/api/util/responses.js
@@ -1,5 +1,3 @@
-const HTTP_STATUS_CODES = ['201', '400', '401', '403', '404', '500'];
-
 /**
  * Format and send an HTTP response.
  *
@@ -8,6 +6,9 @@ const HTTP_STATUS_CODES = ['201', '400', '401', '403', '404', '500'];
  * @param {Object} data JSON body.
  */
 const sendResponse = (res, status, data) => {
+  if (status === 204)
+    return res.status(status).end();
+
   res.status(status);
   res.json(data);
 };
@@ -18,7 +19,7 @@ const sendResponse = (res, status, data) => {
  * components:
  *  responses:
  *    400BadRequest:
- *      description: Bad Request.
+ *      description: Bad request.
  *      content:
  *        application/json:
  *          schema:
@@ -48,7 +49,7 @@ const sendResponse = (res, status, data) => {
  *                type: string
  *                example: This user is not authorized to perform this action.
  *    404NotFound:
- *      description: Not Found.
+ *      description: Not found.
  *      content:
  *        application/json:
  *          schema:
@@ -73,7 +74,7 @@ const sendResponse = (res, status, data) => {
  * Format and send an error HTTP response.
  *
  * @param {Object} res Express response object.
- * @param {Object|String} err Error object or HTTP status code.
+ * @param {Object|Integer} err Error object or HTTP status code.
  * @param {String} message User friendly message to send on response object.
  */
 const sendError = (res, err, message) => {
@@ -87,15 +88,14 @@ const sendError = (res, err, message) => {
 /**
  * Get and return the correct HTTP status code.
  *
- * @param {Object|String} err Error object or HTTP status code.
+ * @param {Object|Integer} err Error object or HTTP status code.
  * @returns {Integer} The HTTP status code.
  */
 const getStatusCode = (err) => {
-  let statusCode = 500;
+  let statusCode = err;
 
   if (err.name === 'ValidationError' || err.code === 11000) statusCode = 400;
   if (err.name === 'CastError') statusCode = 404;
-  if (HTTP_STATUS_CODES.includes(err)) statusCode = parseInt(err);
 
   return statusCode;
 };
@@ -103,7 +103,7 @@ const getStatusCode = (err) => {
 /**
  * Construct JSON body for HTTP error response.
  *
- * @param {Object|String} err Error object or HTTP status code.
+ * @param {Object|Integer} err Error object or HTTP status code.
  * @param {String} msg User friendly message to send on response object.
  * @returns {Object} JSON body.
  */


### PR DESCRIPTION
- POST /api/users/register: On registration create unverified account, generate verification token and email user
- POST /api/users/verify/resend: Given an email, resend verification token
- POST /api/users/verify/:token: If valid password and token, verify user and return JWT
- POST /api/users/reset to request a password reset
- POST /api/users/reset/:token to update password
- GET /api/users/reset/:token to validate a password reset token
- GET /api/users to return entire user profile
- PUT /api/users to update user login info
- GET /api/health to get health profile
- POST /api/health to create health profile
- PUT /api/health to update health profile
- DELETE /api/health to delete health profile
- GET /api/reminders to get all reminders
- GET /api/reminders/:id to get reminder by id
- POST /api/reminders to create reminder
- PUT /api/reminders/:id to update reminder
- DELETE /api/reminders/:id to delete reminder
- GET /api/reminder-types to get all reminder typers
- GET /api/reminder-types/:id to get reminder type by id
- POST /api/reminder-types to create a reminder type
- PUT /api/reminder-types/:id to update a reminder type
- DELETE /api/reminder-types/:id to delete a reminder type